### PR TITLE
Creature Spawner: Toggle Rapid Ability Cooldown

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@ Author:
 Aussiemon
 
 Contributors (alphabetical):
+chibacityblues
 deluxghost
 DragonPi3
 Grimalackt

--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
@@ -20,6 +20,9 @@ local string = string
 local table = table
 local type = type
 
+local rapid_cooldown_enabled = false
+local default_player_abilities = mod:persistent_table("default_player_abilities", {})
+local player_abilities
 
 local Breeds = require("scripts/settings/breed/breeds")
 local MasterItems = require("scripts/backend/master_items")
@@ -559,6 +562,24 @@ mod.assist_player = function(self)
   end
 end
 
+mod.toggle_rapid_cooldown = function ()
+  for _, ability in pairs(mod.ability_names) do
+    if rapid_cooldown_enabled then
+      if default_player_abilities[ability].cooldown then
+        player_abilities[ability].cooldown = default_player_abilities[ability].cooldown
+      end
+      rapid_cooldown_enabled = false
+    else
+      if default_player_abilities[ability].cooldown then
+        player_abilities[ability].cooldown = 1
+      end
+      rapid_cooldown_enabled = true
+    end
+  end
+
+  mod:echo("Rapid Ability Cooldown: " .. (rapid_cooldown_enabled and "on" or "off"))
+end
+
 -- ##########################################################
 -- #################### Hooks ###############################
 
@@ -642,6 +663,12 @@ mod:hook("MinionVisualLoadoutExtension", "init", function (func, self, extension
   cleaned_extension_init_data.inventory.slots = cleaned_inventory_slots
 
   return func(self, extension_init_context, unit, cleaned_extension_init_data, ...)
+end)
+
+mod:hook_require("scripts/settings/ability/player_abilities/player_abilities", function(_player_abilities)
+	default_player_abilities = table.clone(_player_abilities)
+	table.set_readonly(default_player_abilities)
+	player_abilities = _player_abilities
 end)
 
 -- ##########################################################

--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner_data.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner_data.lua
@@ -144,6 +144,44 @@ mod.unit_categories = {
   },
 }
 
+mod.ability_names = {
+	"ogryn_charge",
+	"ogryn_charge_bleed",
+	"ogryn_charge_cooldown_reduction",
+	"ogryn_charge_damage",
+	"ogryn_charge_increased_distance",
+	"ogryn_grenade_box",
+	"ogryn_grenade_box_cluster",
+	"ogryn_grenade_frag",
+	"ogryn_grenade_friend_rock",
+	"ogryn_ranged_stance",
+	"ogryn_taunt_shout",
+	"psyker_chain_lightning",
+	"psyker_discharge_shout",
+	"psyker_force_field",
+	"psyker_force_field_dome",
+	"psyker_force_field_increased_charges",
+	"psyker_overcharge_stance",
+	"psyker_psychic_fortress",
+	"psyker_psychic_fortress_duration_increased",
+	"psyker_smite",
+	"psyker_throwing_knives",
+	"veteran_combat_ability_shout",
+	"veteran_combat_ability_stance",
+	"veteran_combat_ability_stealth",
+	"veteran_frag_grenade",
+	"veteran_krak_grenade",
+	"veteran_smoke_grenade",
+	"zealot_fire_grenade",
+	"zealot_invisibility",
+	"zealot_invisibility_improved",
+	"zealot_relic",
+	"zealot_shock_grenade",
+	"zealot_targeted_dash",
+	"zealot_targeted_dash_improved",
+	"zealot_throwing_knives",
+}
+
 local mod_data = {
   name = mod:localize("mod_name"),
   description = mod:localize("mod_description"),
@@ -201,6 +239,14 @@ mod_data.options = {
       ["default_value"] = true -- Default first option is enabled. In this case true
     },
     
+    { -- Keybind to set rapid ability cooldown
+      ["setting_id"] = "cs_enable_training_grounds_rapid_cooldown_keybind",
+      ["type"] = "keybind",
+      ["keybind_trigger"] = "pressed",
+      ["keybind_type"] = "function_call",
+      ["default_value"] = {},
+      ["function_name"] = "toggle_rapid_cooldown"
+    },
     { -- Keybind for spawning units
       ["setting_id"] = "cs_spawn_keybind",
       ["type"] = "keybind",

--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
@@ -228,4 +228,10 @@ return {
     en = "Choose the keybinding that gets the player out of a disabled state in the Training Grounds.",
     ["zh-cn"] = "选择用于在训练场内解除玩家被控状态的按键。",
   },
+  cs_enable_training_grounds_rapid_cooldown_keybind = {
+    en = "Keybind: Rapid Ability Cooldown"
+  },
+  cs_enable_training_grounds_rapid_cooldown_keybind_description = {
+    en = "Choose the keybinding that toggles Rapid Ability Cooldown (1 second)"
+  },
 }


### PR DESCRIPTION
Change in this PR allows for setting a keybinding that toggles Rapid Ability Cooldown in training grounds. 

When enabled, cooldowns for valid abilities (those with a default cooldown other than nil) are set to one second. Disabling restores the default cooldown.