### PR TITLE
Creature Spawner: Add keybinding to reset the Combat Ability Cooldown

### DIFF
--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
@@ -562,9 +562,8 @@ end
 mod.reset_combat_ability_cooldown = function()
   local local_player_unit = get_player_unit()
   if local_player_unit and is_valid_game_mode() then
-    local ability_extension = ScriptUnit.extension(local_player_unit, "ability_system")
+    local ability_extension = ScriptUnit.has_extension(local_player_unit, "ability_system")
     ability_extension:reduce_ability_cooldown_percentage("combat_ability", 1)
-    mod:echo("Combat ability reset")
   end
 end
 

--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
@@ -559,6 +559,15 @@ mod.assist_player = function(self)
   end
 end
 
+mod.reset_combat_ability_cooldown = function()
+  local local_player_unit = get_player_unit()
+  if local_player_unit and is_valid_game_mode() then
+    local ability_extension = ScriptUnit.extension(local_player_unit, "ability_system")
+    ability_extension:reduce_ability_cooldown_percentage("combat_ability", 1)
+    mod:echo("Combat ability reset")
+  end
+end
+
 mod.toggle_invisibility = function()
   local new_state = not mod.settings["cs_enable_training_grounds_invisibility"]
   mod.settings["cs_enable_training_grounds_invisibility"] = new_state

--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner_data.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner_data.lua
@@ -299,6 +299,14 @@ mod_data.options = {
       ["default_value"] = {},
       ["function_name"] = "assist_player"
     },
+    { -- Keybind to reset combat ability cooldown
+      ["setting_id"] = "cs_reset_combat_ability_cooldown_keybind",
+      ["type"] = "keybind",
+      ["keybind_trigger"] = "pressed",
+      ["keybind_type"] = "function_call",
+      ["default_value"] = {},
+      ["function_name"] = "reset_combat_ability_cooldown"
+    },
   }
 }
 

--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
@@ -286,6 +286,12 @@ return {
     ["zh-cn"] = "选择用于在训练场内解除玩家被控状态的按键。",
     ru = "Выберите комбинацию клавиш или клавишу, при нажатии на которую игрок будет поднят, если он выведен из строя на Стрельбище.",
   },
+  cs_reset_combat_ability_cooldown_keybind = {
+    en = "Keybind: Reset Combat Ability Cooldown"
+  },
+  cs_reset_combat_ability_cooldown_keybind_description = {
+    en = "Choose the keybinding that resets the Combat Ability Cooldown in the Training Grounds"
+  },
   cs_enable_training_grounds_invisibility_keybind = {
     en = "Keybind: Toggle Player Invisibility"
   },

--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
@@ -290,7 +290,7 @@ return {
     en = "Keybind: Reset Combat Ability Cooldown"
   },
   cs_reset_combat_ability_cooldown_keybind_description = {
-    en = "Choose the keybinding that resets the Combat Ability Cooldown in the Training Grounds"
+    en = "Choose the keybinding that resets the Combat Ability Cooldown in the Training Grounds."
   },
   cs_enable_training_grounds_invisibility_keybind = {
     en = "Keybind: Toggle Player Invisibility"


### PR DESCRIPTION
After some digging, I found a much cleaner way to reset the Combat Ability Cooldown that doesn't require any hooks. 