### PR TITLE
Fix crash during creature spawner trial when trying to spawn additional enemies

### DIFF
--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
@@ -523,7 +523,8 @@ local function enemies_loop_condition_func(scenario_system, player, scenario_dat
 
                 local spawn_params = {
                   optional_aggro_state = "aggroed",
-                  optional_health_modifier = health_modifier
+                  optional_target_unit = player.player_unit,
+                  optional_health_modifier = health_modifier,
                 }
                 new_unit = Managers.state.minion_spawn:spawn_minion(breed_name, position, rotation, 2, spawn_params)
                 spawner_data.woundless = true

--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
@@ -521,7 +521,11 @@ local function enemies_loop_condition_func(scenario_system, player, scenario_dat
                   health_modifier = 0.4
                 end
 
-                new_unit = Managers.state.minion_spawn:spawn_minion(breed_name, position, rotation, 2, "aggroed", player.player_unit, nil, nil, nil, nil, health_modifier)
+                local spawn_params = {
+                  optional_aggro_state = "aggroed",
+                  optional_health_modifier = health_modifier
+                }
+                new_unit = Managers.state.minion_spawn:spawn_minion(breed_name, position, rotation, 2, spawn_params)
                 spawner_data.woundless = true
                 active_units[new_unit] = spawner_data
               else


### PR DESCRIPTION
This fixes a crash when trying to spawn additional enemies in the middle of a trial in creature_spawner.

The old version tries to call a function with this signature:
```lua
MinionSpawnManager.spawn_minion = function (self, breed_name, position, rotation, side_id, optional_aggro_state, optional_target_unit, optional_spawner_unit, optional_group_id, optional_mission_objective_id, optional_attack_selection_template_name)
```

However in the current game source code, this function has been updated to take optional arguments in a table:
```lua
MinionSpawnManager.spawn_minion = function (self, breed_name, position, rotation, side_id, optional_param_table)
```

I've left out the `optional_target_unit` field since it doesn't seem to be accessed in the new implementation of the function, however if needed (or if I'm missing something) it could be added back to the table quite easily:
```lua
local spawn_params = {
  optional_aggro_state = "aggroed",
  optional_target_unit = player.player_unit,
  optional_health_modifier = health_modifier
}
```

I'm not super familiar with the codebase or Lua, so I'm open to suggestions :)