### PR TITLE
Update for Skitarii

### DIFF
--- a/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
+++ b/creature_spawner/scripts/mods/creature_spawner/creature_spawner.lua
@@ -250,15 +250,12 @@ local function enemies_loop_start_func(scenario_system, player_, scenario_data_,
 end
 
 local function enemies_loop_condition_func(scenario_system, player, scenario_data, step_data, t)
-  if mod.settings["cs_enable_training_grounds_invisibility"] then
-    if not scenario_system:has_scenario_buff(player.player_unit, "tg_player_unperceivable") then
-      scenario_system:add_scenario_buff(player.player_unit, "tg_player_unperceivable", scenario_data, t)
-    end
-  else
-    if scenario_system:has_scenario_buff(player.player_unit, "tg_player_unperceivable") then
-      scenario_system:remove_scenario_buff(player.player_unit, "tg_player_unperceivable", scenario_data)
-    end
-  end
+  -- Invisibility (tg_player_unperceivable) is managed solely by our override of
+  -- the vanilla sr_unperceivable_loop step (see hook below). Doing it here too
+  -- caused a tug-of-war: the init scenario's sr_unperceivable_loop re-added the
+  -- buff every frame while this parallel step removed it, so the unperceivable
+  -- keyword toggled on/off each frame => enemies saw the player for a split
+  -- second on a loop. Single owner = no flicker.
 
   if not mod.settings["cs_enable_training_grounds_sound_muffler"] then
     Wwise.set_state("music_zone", "on")
@@ -850,12 +847,83 @@ end
 mod:hook_require(shooting_range_steps_path, function(instance)
   instance.enemies_loop.start_func = enemies_loop_start_func
   instance.enemies_loop.condition_func = enemies_loop_condition_func
+
+  -- Vanilla sr_unperceivable_loop re-adds tg_player_unperceivable EVERY frame
+  -- (it's a forever-looping step in the init scenario). That ignores our
+  -- invisibility toggle entirely, so enemies could never reliably see you, and
+  -- it fought any buff removal elsewhere => 1-frame on/off flicker.
+  --
+  -- Make this step the single owner of the buff and have it respect the toggle:
+  -- add when invisibility is on, remove when off. Runs in the init scenario, the
+  -- same context add/remove/has_scenario_buff operate on (self._current_scenario),
+  -- so the bookkeeping stays consistent.
+  if instance.sr_unperceivable_loop then
+    instance.sr_unperceivable_loop.condition_func = function(scenario_system, player, scenario_data, step_data, t)
+      local player_unit = player.player_unit
+
+      if not HEALTH_ALIVE[player_unit] then
+        return false
+      end
+
+      local buff_extension = ScriptUnit.has_extension(player_unit, "buff_system")
+      if not buff_extension then
+        return false
+      end
+
+      local want_invis = mod.settings["cs_enable_training_grounds_invisibility"]
+
+      -- Sweep-based, no stored handle. Index-tracking leaked orphan buffs: the
+      -- player unit blips not-alive during hub<->training_grounds transitions,
+      -- which dropped our tracked index without removing the buff, so a second
+      -- tg_player_unperceivable kept the keyword alive after toggling off.
+      -- Instead, every frame reconcile actual buff instances to the desired state:
+      -- invisibility on  -> ensure exactly one tg_player_unperceivable exists
+      -- invisibility off -> remove every tg_player_unperceivable (clears orphans)
+      local indices
+      local buffs_by_index = buff_extension._buffs_by_index
+      if buffs_by_index then
+        for index, buff in pairs(buffs_by_index) do
+          if buff and buff.template_name and buff:template_name() == "tg_player_unperceivable" then
+            indices = indices or {}
+            indices[#indices + 1] = index
+          end
+        end
+      end
+      local count = indices and #indices or 0
+
+      if want_invis then
+        if count == 0 then
+          buff_extension:add_externally_controlled_buff("tg_player_unperceivable", t)
+        end
+      elseif count > 0 then
+        for i = 1, count do
+          buff_extension:remove_externally_controlled_buff(indices[i], nil)
+        end
+      end
+
+      return false
+    end
+  end
 end)
 
-mod:hook_require(shooting_range_scenarios_path, function(instance)
-  if instance and instance.init and instance.init.steps and #instance.init.steps == 7 then
-    table.remove(instance.init.steps, 3)
-  end
+-- NOTE: removed the old `table.remove(instance.init.steps, 3)` here. After the
+-- patch reordered the scenario steps, index 3 is portal_loop (not the perception
+-- step it was meant to delete), so the removal both failed to fix invisibility
+-- and deleted the shooting-range portals. We now neutralize the perception step
+-- by identity above instead of removing it by stale index.
+
+-- Patch 1.11+ added a game-mode flag `disable_minion_perception` (true for the
+-- shooting range) which spawns every minion with perception disabled. Such a
+-- minion nulls its target every frame in MinionPerceptionExtension.update, so a
+-- force-aggro'd enemy takes a single step toward the player then stops, retrying
+-- forever. That made spawned enemies useless when invisibility was off.
+--
+-- Force perception ON for spawned minions. The tg_player_unperceivable buff
+-- (managed by our sr_unperceivable_loop override) is then the single, clean gate:
+--   invisibility on  -> player is not a valid target -> minions idle (no stutter)
+--   invisibility off -> player is a valid target      -> minions perceive & attack
+mod:hook_origin("GameModeManager", "should_disable_minion_perception", function (self)
+  return false
 end)
 
 mod:hook_origin("MinionSuppressionExtension", "_get_threshold_and_max_value", function (self)


### PR DESCRIPTION
Game patches 1.11.0 / 1.12.0 (June 2026) changed how the shooting range gates AI targeting, which broke Creature Spawner's "training grounds invisibility" toggle. Spawned enemies either ignored the player entirely or stuttered (step toward the player, stop, retry on a ~1s loop) regardless of the toggle state.

The root cause was two independent targeting mechanisms that both needed handling, plus a stale step-removal that had started deleting the wrong scenario step. This PR fixes all three. Only scripts/mods/creature_spawner/creature_spawner.lua changes; no data, localization, or .mod changes.

Background — how the Psykhanium gates AI targeting Two separate systems decide whether dummies can see the player:

The tg_player_unperceivable buff on the player. Its unperceivable keyword removes the player from side.ai_target_units. Patch 1.11 moved vanilla's buff-add into a forever-looping sr_unperceivable_loop step in the init scenario, so it gets re-added every frame. The disable_minion_perception game-mode flag (game_mode_settings_shooting_range.disable_minion_perception = true), new in the patch. It spawns every dummy with perception disabled, so a minion nulls its target every frame in MinionPerceptionExtension.update and can never hold aggro. Changes
1. Single owner for the invisibility buff (no more frame flicker)

Previously the mod's parallel enemies_loop.condition_func added/removed tg_player_unperceivable while vanilla's sr_unperceivable_loop re-added it every frame. The two fought each other, toggling the unperceivable keyword on/off each frame — enemies saw the player for a split second on a loop.

The mod's enemies_loop no longer touches the buff. Instead it overrides sr_unperceivable_loop.condition_func to be the single owner, running in the same init scenario context the buff bookkeeping operates on. It adds the buff when invisibility is on and removes it when off.

2. Per-frame sweep instead of a stored buff handle (no orphan leaks)

Index/handle tracking leaked orphaned buffs: the player unit briefly reads not-alive during hub ↔ training-grounds transitions, which dropped the tracked index without removing the buff. A second tg_player_unperceivable then kept the keyword alive even after toggling invisibility off.

The override now reconciles actual buff instances to the desired state every frame by scanning buff_extension._buffs_by_index:

invisibility on → ensure exactly one tg_player_unperceivable exists invisibility off → remove every tg_player_unperceivable (clears any orphans)
3. Removed the stale table.remove(init.steps, 3)

After the patch reordered the scenario steps, index 3 is now portal_loop, not the perception step the removal was meant to delete. The old code therefore failed to fix invisibility and deleted the shooting-range portals. The perception step is now neutralized by identity (the override above) rather than by stale index, and the table.remove is gone.

4. Force minion perception on (fixes the stutter — the real blocker)

mod:hook_origin("GameModeManager", "should_disable_minion_perception", function (self)
  return false
end)
With the new disable_minion_perception flag, force-aggro'd enemies took a single step toward the player then stopped, retrying forever — useless when invisibility was off. Forcing perception on makes the tg_player_unperceivable buff the single, clean gate:

invisibility on → player is not a valid target → minions idle (no stutter) invisibility off → player is a valid target → minions perceive and attack Testing
Toggle "training grounds invisibility" on/off in the Psykhanium with spawned enemies:

Off: enemies perceive and attack immediately, no step-stop-retry stutter. On: enemies idle, no 1-frame flicker of aggro.
Walk through hub ↔ training-grounds transitions repeatedly, then toggle off — no lingering invisibility from orphaned buffs. Shooting-range portals still present (regression from the old table.remove).